### PR TITLE
Restrict freedrawn co-ords to 6 decimal places

### DIFF
--- a/datasette_leaflet_freedraw/static/datasette-leaflet-freedraw.js
+++ b/datasette_leaflet_freedraw/static/datasette-leaflet-freedraw.js
@@ -87,7 +87,7 @@ function configureMap(input) {
     let geojson = {
       type: "MultiPolygon",
       coordinates: event.latLngs.map((shape) => [
-        shape.map((p) => [p.lng, p.lat]),
+        shape.map((p) => [p.lng.toFixed(6), p.lat.toFixed(6)]),
       ]),
     };
     input.value = JSON.stringify(geojson);


### PR DESCRIPTION
6 decimal places is accurate to c. 0.1m
https://gis.stackexchange.com/a/8674/25096

As suggested at https://twitter.com/simonw/status/1365821972442046464 by @simonw 
(5dp with accuracy of c 1m might be good enough, wasn't sure.)