### PR TITLE
Allow drawing on a map on table pages for tables with a geometry column

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -23,6 +23,9 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Install SpatiaLite
+      run: |
+        sudo apt-get install libsqlite3-mod-spatialite
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
@@ -37,7 +40,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: "3.10"
     - uses: actions/cache@v2
       name: Configure pip caching
       with:
@@ -55,4 +58,3 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,3 @@ jobs:
     - name: Run tests
       run: |
         pytest
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
+        pip install https://github.com/simonw/datasette/archive/refs/heads/filters-from-request.zip
     - name: Run tests
       run: |
         pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -21,10 +21,12 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Install SpatiaLite
+      run: |
+        sudo apt-get install libsqlite3-mod-spatialite
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
-        pip install https://github.com/simonw/datasette/archive/refs/heads/filters-from-request.zip
     - name: Run tests
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Install this plugin in the same environment as Datasette.
 
 ## Usage
 
-This plugin looks for input fields on a page with names ending in `_freedraw` - it replaces them with a Leaflet map interface that includes the [FreeDraw](https://freedraw.herokuapp.com/) Leaflet plugin.
+If a table has a SpatiaLite `geometry` column, the plugin will add a map interface to the table page allowing users to draw a shape on the map to find rows with a geometry that intersects that shape.
 
-Configure canned queries with inputs called `freedraw` or ending in `_freedraw` to trigger the map interface.
+The plugin can also work with arbitrary SQL queries. There it looks for input fields with a name of `freedraw` or that ends in `_freedraw` and replaces them with a map interface.
+
+The map interface uses the [FreeDraw](https://freedraw.herokuapp.com/) Leaflet plugin.
 
 ## Demo
 

--- a/datasette_leaflet_freedraw/__init__.py
+++ b/datasette_leaflet_freedraw/__init__.py
@@ -1,5 +1,60 @@
 from datasette import hookimpl
+from datasette.filters import FilterArguments
+import json
 import textwrap
+
+
+async def geometry_columns_for_table(datasette, database, table):
+    # Returns [{"column": spatial_index_enabled (boolean)}]
+    sql = """
+        select f_geometry_column, spatial_index_enabled
+        from geometry_columns
+        where lower(f_table_name) = lower(:table)
+    """
+    db = datasette.get_database(database)
+    return {
+        r["f_geometry_column"]: bool(r["spatial_index_enabled"])
+        for r in await db.execute(sql, {"table": table})
+    }
+
+
+@hookimpl
+def filters_from_request(request, database, table, datasette):
+    async def inner():
+        geometry_columns = await geometry_columns_for_table(datasette, database, table)
+        if not geometry_columns:
+            return
+        freedraw = request.args.get("_freedraw", "")
+        try:
+            geojson = json.loads(freedraw)
+        except ValueError:
+            return
+        # Just use the first geometry column
+        column, spatial_index_enabled = list(geometry_columns.items())[0]
+        where_clauses = [
+            "Intersects(GeomFromGeoJSON(:freedraw), [{}]) = 1".format(column)
+        ]
+        params = {"freedraw": json.dumps(geojson)}
+        # Spatial index support, if possible
+        if spatial_index_enabled:
+            where_clauses.append(
+                textwrap.dedent(
+                    """
+            [{table}].rowid in (select rowid from SpatialIndex where f_table_name = :freedraw_table
+            and search_frame = GeomFromGeoJSON(:freedraw))
+            """.format(
+                        table=table
+                    )
+                ).strip()
+            )
+            params["freedraw_table"] = table
+        return FilterArguments(
+            where_clauses,
+            params=params,
+            human_descriptions=["geometry intersects the specified map area"],
+        )
+
+    return inner
 
 
 @hookimpl

--- a/datasette_leaflet_freedraw/static/datasette-leaflet-freedraw.js
+++ b/datasette_leaflet_freedraw/static/datasette-leaflet-freedraw.js
@@ -7,10 +7,31 @@ let DATASETTE_TILE_LAYER_OPTIONS = {
 };
 
 window.addEventListener("load", () => {
+  /* Only run and load dependencies if either there's a input[name=...freedraw]
+     or there is an explicit datasette.leaflet_freedraw.show_for_table = true */
+  if (datasette.leaflet_freedraw.show_for_table) {
+    // Insert a name=freedraw input element
+    let input = document.createElement("input");
+    input.setAttribute("name", "_freedraw");
+    input.setAttribute("type", "text");
+    input.setAttribute("placeholder", "Map GeoJSON");
+    document.querySelector("form.filters").appendChild(input);
+    if (datasette.leaflet_freedraw.current_geojson) {
+      input.value = JSON.stringify(datasette.leaflet_freedraw.current_geojson);
+    }
+    // And remove any existing hidden inputs
+    Array.from(document.querySelectorAll("input[name=_freedraw][type=hidden]")).forEach(el => {
+      el.parentNode.removeChild(el);
+    });
+  }
   let inputs = [
-    ...document.querySelectorAll("input[name=freedraw]"),
-    ...document.querySelectorAll("input[name$=_freedraw]"),
+    ...document.querySelectorAll("input[name=freedraw][type=text]"),
+    ...document.querySelectorAll("input[name$=_freedraw][type=text]"),
   ];
+  if (!inputs.length) {
+    return;
+  }
+  console.log({inputs})
   /* Load modules and CSS */
   const loadDependencies = (callback) => {
     let loaded = [];

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version=VERSION,
     packages=["datasette_leaflet_freedraw"],
     entry_points={"datasette": ["leaflet_freedraw = datasette_leaflet_freedraw"]},
-    install_requires=["datasette>=0.54", "datasette-leaflet>=0.2"],
+    install_requires=["datasette>=0.60a0", "datasette-leaflet>=0.2"],
     extras_require={"test": ["pytest", "pytest-asyncio"]},
     tests_require=["datasette-leaflet-freedraw[test]"],
     package_data={

--- a/tests/test_leaflet_freedraw.py
+++ b/tests/test_leaflet_freedraw.py
@@ -1,7 +1,10 @@
 from datasette.app import Datasette
+from datasette.utils.sqlite import sqlite3
 from datasette.utils.asgi import Request
+from datasette.utils import find_spatialite
 from datasette_leaflet_freedraw import extra_body_script, extra_js_urls
 import pytest
+import secrets
 
 
 @pytest.mark.asyncio
@@ -57,3 +60,78 @@ async def test_extra_body_script():
         "    current_geojson: null\n"
         "};"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "table,expect_map,expect_spatial_index",
+    (
+        (
+            "places_no_spatialite",
+            False,
+            False,
+        ),
+        (
+            "places_spatialite",
+            True,
+            False,
+        ),
+        (
+            "places_spatialite_spatial_index",
+            True,
+            True,
+        ),
+    ),
+)
+async def test_show_for_table_only_if_spatialite(
+    table, expect_map, expect_spatial_index
+):
+    dbname = "geodb{}".format(secrets.token_hex(4))
+    datasette = Datasette(memory=True, files=[], sqlite_extensions=["spatialite"])
+    db = datasette.add_memory_database(dbname)
+
+    def setup(db):
+        db.enable_load_extension(True)
+        db.execute("SELECT load_extension(?)", [find_spatialite()])
+        db.execute("SELECT InitSpatialMetadata(1)")
+        db.execute(
+            "CREATE TABLE places_no_spatialite (id integer primary key, name text)"
+        )
+        db.execute("CREATE TABLE places_spatialite (id integer primary key, name text)")
+        db.execute(
+            "SELECT AddGeometryColumn('places_spatialite', 'geometry', 4326, 'POINT', 'XY');"
+        )
+        db.execute(
+            "CREATE TABLE places_spatialite_spatial_index (id integer primary key, name text)"
+        )
+        db.execute(
+            "SELECT AddGeometryColumn('places_spatialite_spatial_index', 'geometry', 4326, 'POINT', 'XY');"
+        )
+        db.execute(
+            "SELECT CreateSpatialIndex('places_spatialite_spatial_index', 'geometry');"
+        )
+
+    await db.execute_write_fn(setup, block=True)
+
+    html = (await datasette.client.get("/{}/{}".format(dbname, table))).text
+    if expect_map:
+        assert "show_for_table: true," in html
+    else:
+        assert "show_for_table: false," in html
+
+    if expect_spatial_index:
+        # Feed it some GeoJSON and see if the SQL changes to the right value
+        html2 = (
+            await datasette.client.get(
+                "/{}/{}?_freedraw={}".format(dbname, table, "{}")
+            )
+        ).text
+        # Extract the SQL from the "View and edit SQL" link
+        sql = html2.split('<p><a class="not-underlined" title="')[1].split('" href')[0]
+        assert sql == (
+            "select id, name, geometry from places_spatialite_spatial_index "
+            "where Intersects(GeomFromGeoJSON(:freedraw), [geometry]) = 1 "
+            "and [places_spatialite_spatial_index].rowid in "
+            "(select rowid from SpatialIndex where f_table_name = :freedraw_table\n"
+            "and search_frame = GeomFromGeoJSON(:freedraw)) order by id limit 101"
+        )

--- a/tests/test_leaflet_freedraw.py
+++ b/tests/test_leaflet_freedraw.py
@@ -1,4 +1,5 @@
 from datasette.app import Datasette
+from datasette.utils.asgi import Request
 from datasette_leaflet_freedraw import extra_body_script, extra_js_urls
 import pytest
 
@@ -39,10 +40,20 @@ def test_extra_template_vars():
     ]
 
 
-def test_extra_body_script():
-    assert extra_body_script(datasette=Datasette([], memory=True)).strip() == (
+@pytest.mark.asyncio
+async def test_extra_body_script():
+    assert (
+        await extra_body_script(
+            datasette=Datasette([], memory=True),
+            request=Request.fake("/"),
+            database=None,
+            table=None,
+        )()
+    ).strip() == (
         "window.datasette = window.datasette || {};\n"
         "datasette.leaflet_freedraw = {\n"
         "    FREEDRAW_URL: '/-/static-plugins/datasette-leaflet-freedraw/leaflet-freedraw.esm.js',\n"
+        "    show_for_table: false,\n"
+        "    current_geojson: null\n"
         "};"
     )


### PR DESCRIPTION
Refs #7, https://github.com/simonw/datasette/issues/473 and https://github.com/simonw/datasette/pull/1559

Still needed:

- [x] Run JavaScript on table page (if a geometry column is present) and show the map
- [x] Release of Datasette with the new `filters_from_request` plugin hook that this uses
- [x] Tests
- [x] Updated documentation
